### PR TITLE
Parameter model binding to resolve method dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Sajya is an open-source project aiming to implement the JSON-RPC 2.0 server spec
 
 - Quick and straightforward route adding
 - Validation of parameters and custom messages
+- Parameter model binding to resolve method dependencies
 - Support batch requests
 - Support notification requests
 

--- a/src/BindsParameters.php
+++ b/src/BindsParameters.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server;
+
+interface BindsParameters
+{
+    /**
+     * Maps the parameters of the RPC request to the parameters of the Procedure method.
+     *
+     * @return string[] Array where keys are names of the PHP method parameters,
+     *                  and the values are the parameters of the RPC request to
+     *                  make the instances based on.
+     *                  The resolution uses the default key name of the Model, which
+     *                  is 'id' by default and can be customised using the 'getRouteKeyName()'
+     *                  method inside the Model class. For example ['user'=>'user_id']
+     *                  will ensure '$user' parameter of the Procedure method would
+     *                  receive an instance of the hinted Model type with the 'id'
+     *                  matching the 'user_id' parameter in the RPC request.
+     *                  The key to be used can also be customised the same way as
+     *                  in Route Model Binding, e.g.: ['user'=>'address:email']
+     *                  would make an instance of the hinted type of the '$user'
+     *                  parameter of the Procedure method, where the email attribute
+     *                  of the Model is set by the 'address' parameter in the RPC
+     *                  request.
+     *
+     */
+    public function getBindings(): array;
+    
+    /**
+     * Makes the parameter to be injected into the Procedure method.
+     *
+     * @param string $parameterName The name of the PHP method parameter to resolve.
+     *
+     * @return false|null|mixed The class instance to inject or false to use default resolution.
+     *                          For optional parameters, null can be returned as well.
+     */
+    public function resolveParameter(string $parameterName);
+}

--- a/src/BoundMethod.php
+++ b/src/BoundMethod.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Reflector;
+
+/**
+ * Class BoundMethod
+ */
+class BoundMethod extends \Illuminate\Container\BoundMethod
+{
+    /**
+     * Get the dependency for the given call parameter.
+     *
+     * @param \Illuminate\Container\Container $container
+     * @param \ReflectionParameter            $parameter
+     * @param array                           $parameters
+     * @param array                           $dependencies
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
+    protected static function addDependencyForCallParameter($container, $parameter, array &$parameters, &$dependencies)
+    {
+        // Attempt custom binding resolution
+        foreach ($dependencies as $dependency) {
+            if (is_object($dependency) && $dependency instanceof BindsParameters) {
+                if (($maybeDependency = $dependency->resolveParameter($parameter->getName())) !== false) {
+                    if (is_null($maybeDependency)) {
+                        if ($parameter->isOptional()) {
+                            $dependencies[] = $maybeDependency;
+                            return;
+                        } else {
+                            throw new BindingResolutionException('Custom resolution logic returned `null`, but parameter is not optional.', -32000);
+                        }
+                    }
+                    
+                    $paramType = Reflector::getParameterClassName($parameter);
+                    if ($maybeDependency instanceof $paramType) {
+                        $dependencies[] = $maybeDependency;
+                        return;
+                    } else {
+                        throw new BindingResolutionException('Custom resolution logic returned a parameter with an invalid type.', -32001);
+                    }
+                }
+            }
+        }
+        
+        // Attempt resolution based on parameter mapping
+        foreach ($dependencies as $dependency) {
+            if (is_object($dependency) && $dependency instanceof BindsParameters) {
+                $parameterMap = $dependency->getBindings();
+                $paramName = $parameter->getName();
+                if (isset($parameterMap[$paramName])) {
+                    $instance = $container->make(Reflector::getParameterClassName($parameter));
+                    if (!$instance instanceof UrlRoutable) {
+                        throw new BindingResolutionException('Mapped parameter type must implement `UrlRoutable` interface.', -32002);
+                    }
+                    [ $instanceValue, $instanceField ] = self::getValueAndFieldFromMapEntry($parameterMap[$paramName]);
+                    if (!$model = $instance->resolveRouteBinding($instanceValue, $instanceField)) {
+                        throw (new ModelNotFoundException('', -32003))->setModel(get_class($instance), [$instanceValue]);
+                    }
+                    $dependencies[] = $model;
+                    return;
+                }
+            }
+        }
+        
+        parent::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
+    }
+    
+    private static function getValueAndFieldFromMapEntry($mapEntry)
+    {
+        $entry = explode(':', $mapEntry);
+        return [request($entry[0]), $entry[1] ?? null];
+    }
+}

--- a/src/HandleProcedure.php
+++ b/src/HandleProcedure.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\App;
 use Illuminate\Validation\ValidationException;
 use RuntimeException;
 use Sajya\Server\Exceptions\InternalErrorException;
@@ -48,7 +47,7 @@ class HandleProcedure implements ShouldQueue
     public function handle()
     {
         try {
-            return App::call($this->procedure);
+            return BoundMethod::call(app(), $this->procedure);
         } catch (HttpException | RuntimeException | Exception $exception) {
             $message = $exception->getMessage();
 

--- a/tests/Expected/Requests/testModelBindingCustomLogic.json
+++ b/tests/Expected/Requests/testModelBindingCustomLogic.json
@@ -1,0 +1,8 @@
+{
+    "jsonrpc": "2.0",
+    "method": "fixture@getUserNameCustomLogic",
+    "params": {
+        "user": 3
+    },
+    "id": 1
+}

--- a/tests/Expected/Requests/testModelBindingCustomLogicNullable.json
+++ b/tests/Expected/Requests/testModelBindingCustomLogicNullable.json
@@ -1,0 +1,8 @@
+{
+    "jsonrpc": "2.0",
+    "method": "fixture@getUserNameCustomLogicNullable",
+    "params": {
+        "user": 3
+    },
+    "id": 1
+}

--- a/tests/Expected/Requests/testModelBindingSimpleCustomKey.json
+++ b/tests/Expected/Requests/testModelBindingSimpleCustomKey.json
@@ -1,0 +1,8 @@
+{
+    "jsonrpc": "2.0",
+    "method": "fixture@getUserNameCustomKey",
+    "params": {
+        "user": "test@domain.com"
+    },
+    "id": 1
+}

--- a/tests/Expected/Requests/testModelBindingSimpleDefaultKey.json
+++ b/tests/Expected/Requests/testModelBindingSimpleDefaultKey.json
@@ -1,0 +1,8 @@
+{
+    "jsonrpc": "2.0",
+    "method": "fixture@getUserNameDefaultKey",
+    "params": {
+        "user": 1
+    },
+    "id": 1
+}

--- a/tests/Expected/Responses/testModelBindingCustomLogic.json
+++ b/tests/Expected/Responses/testModelBindingCustomLogic.json
@@ -1,0 +1,5 @@
+{
+    "id": 1,
+    "result": "User 3",
+    "jsonrpc": "2.0"
+}

--- a/tests/Expected/Responses/testModelBindingCustomLogicNullable.json
+++ b/tests/Expected/Responses/testModelBindingCustomLogicNullable.json
@@ -1,0 +1,5 @@
+{
+    "id": 1,
+    "result": "No user",
+    "jsonrpc": "2.0"
+}

--- a/tests/Expected/Responses/testModelBindingSimpleCustomKey.json
+++ b/tests/Expected/Responses/testModelBindingSimpleCustomKey.json
@@ -1,0 +1,5 @@
+{
+    "id": 1,
+    "result": "User 2",
+    "jsonrpc": "2.0"
+}

--- a/tests/Expected/Responses/testModelBindingSimpleDefaultKey.json
+++ b/tests/Expected/Responses/testModelBindingSimpleDefaultKey.json
@@ -1,0 +1,5 @@
+{
+    "id": 1,
+    "result": "User 1",
+    "jsonrpc": "2.0"
+}

--- a/tests/FixtureProcedure.php
+++ b/tests/FixtureProcedure.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Sajya\Server\Tests;
 
 use Illuminate\Config\Repository;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Sajya\Server\Exceptions\RuntimeRpcException;
@@ -85,7 +88,63 @@ class FixtureProcedure extends Procedure
 
         return $result;
     }
-
+    
+    /**
+     * @param FixtureRequest $request
+     * @param User           $userById User resolved by the default resolution logic using ID as key.
+     *
+     * @return string
+     */
+    public function getUserNameDefaultKey(FixtureRequest $request, User $userById): string
+    {
+        return $userById->getAttribute('name');
+    }
+    
+    /**
+     * @param FixtureRequest $request
+     * @param User           $userByEmail User resolved by the default resolution logic using Email as key.
+     *
+     * @return string
+     */
+    public function getUserNameCustomKey(FixtureRequest $request, User $userByEmail): string
+    {
+        return $userByEmail->getAttribute('name');
+    }
+    
+    /**
+     * @param FixtureRequest $request
+     * @param User           $userCustom User resolved by the custom resolution logic.
+     *
+     * @return string
+     */
+    public function getUserNameCustomLogic(FixtureRequest $request, User $userCustom): string
+    {
+        return $userCustom->getAttribute('name');
+    }
+    
+    /**
+     * @param FixtureRequest $request
+     * @param null|User      $userCustom User resolved by the custom resolution logic.
+     *
+     * @return string
+     */
+    public function getUserNameCustomLogicNullable(FixtureRequest $request, ?User $userCustom = null): string
+    {
+        return is_null($userCustom) ? 'No user' : $userCustom->getAttribute('name');
+    }
+    
+    /**
+     * @param FixtureRequest $request
+     * @param Filesystem $wrongTypeVar Should trigger an exception, because
+     *                                 it does not implement {@see UrlRoutable}.
+     *
+     * @return string
+     */
+    public function getUserNameWrong(FixtureRequest $request, Filesystem $wrongTypeVar): string
+    {
+        return gettype($wrongTypeVar);
+    }
+    
     public function internalError(): void
     {
         abort(500);

--- a/tests/FixtureRequest.php
+++ b/tests/FixtureRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server\Tests;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Sajya\Server\BindsParameters;
+
+class FixtureRequest extends FormRequest implements BindsParameters
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'user' => 'bail|required|max:255',
+        ];
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function getBindings(): array
+    {
+        return [
+            'userById'    => 'user',
+            'userByEmail' => 'user:email',
+            'wrongTypeVar'=> 'user'
+        ];
+    }
+    
+    /**
+     * @inheritDoc
+     *
+     * @return null|false|\Illuminate\Database\Eloquent\Model
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function resolveParameter(string $parameterName)
+    {
+        if ('userCustom' === $parameterName) {
+            $user = app()->make(User::class);
+            return $user->resolveRouteBinding($this->input('user'));
+        }
+        return false;
+    }
+}

--- a/tests/Unit/BindingTest.php
+++ b/tests/Unit/BindingTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server\Tests\Unit;
+
+use Closure;
+use Generator;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Testing\TestResponse;
+use Sajya\Server\Tests\TestCase;
+
+class BindingTest extends TestCase
+{
+    /**
+     * @return Generator
+     */
+    public function exampleCalls(): Generator
+    {
+        yield ['testModelBindingSimpleDefaultKey', function () {
+            config()->set('app.debug', true);
+            $userMock = \Mockery::mock(User::class);
+            $userMock->shouldReceive('resolveRouteBinding')
+                     ->once()
+                     ->with(1, null)
+                     ->andReturnSelf();
+            $userMock->shouldReceive('getAttribute')
+                     ->once()
+                     ->with('name')
+                     ->andReturn('User 1');
+            app()->instance(User::class, $userMock);
+        }];
+        yield ['testModelBindingSimpleCustomKey', function () {
+            config()->set('app.debug', true);
+            $userMock = \Mockery::mock(User::class);
+            $userMock->shouldReceive('resolveRouteBinding')
+                     ->once()
+                     ->with('test@domain.com', 'email')
+                     ->andReturnSelf();
+            $userMock->shouldReceive('getAttribute')
+                     ->once()
+                     ->with('name')
+                     ->andReturn('User 2');
+            app()->instance(User::class, $userMock);
+        }];
+        yield ['testModelBindingCustomLogic', function () {
+            config()->set('app.debug', true);
+            $userMock = \Mockery::mock(User::class);
+            $userMock->shouldReceive('resolveRouteBinding')
+                     ->once()
+                     ->with(3)
+                     ->andReturnSelf();
+            $userMock->shouldReceive('getAttribute')
+                     ->once()
+                     ->with('name')
+                     ->andReturn('User 3');
+            app()->instance(User::class, $userMock);
+        }];
+        yield ['testModelBindingCustomLogicNullable', function () {
+            config()->set('app.debug', true);
+            $userMock = \Mockery::mock(User::class);
+            $userMock->shouldReceive('resolveRouteBinding')
+                     ->once()
+                     ->with(3)
+                     ->andReturnNull();
+            $userMock->shouldReceive('get')
+                     ->never()
+                     ->with('name');
+            app()->instance(User::class, $userMock);
+        }];
+    }
+
+    /**
+     * @param string       $file
+     * @param Closure|null $before
+     * @param Closure|null $after
+     * @param string       $route
+     *
+     * @throws \JsonException
+     * @dataProvider exampleCalls
+     *
+     */
+    public function testHasCorrectRequestResponse(
+        string $file,
+        Closure $before = null,
+        Closure $after = null,
+        string $route = 'rpc.point'
+    ): void {
+        if ($before !== null) {
+            $before();
+        }
+
+        $response = $this->callRPC($file, $route);
+
+        if ($after !== null) {
+            $after($response);
+        }
+    }
+
+    /**
+     * @param string $path
+     * @param string $route
+     *
+     * @throws \JsonException
+     *
+     * @return TestResponse
+     */
+    private function callRPC(string $path, string $route): TestResponse
+    {
+        $request = file_get_contents("./tests/Expected/Requests/$path.json");
+        $response = file_get_contents("./tests/Expected/Responses/$path.json");
+
+        return $this
+            ->call('POST', route($route), [], [], [], [], $request)
+            ->assertOk()
+            ->assertHeader('content-type', 'application/json')
+            ->assertJson(
+                json_decode($response, true, 512, JSON_THROW_ON_ERROR)
+            );
+    }
+    
+    /**
+     * @testdox We should get an error, if null is returned by {@see BindsParameters::resolveParameter()}
+     *          when the related Procedure method does not define the parameter as optional.
+     */
+    public function testCutomLogicInvalidNull()
+    {
+        config()->set('app.debug', false);
+        $userMock = \Mockery::mock(User::class);
+        $userMock->shouldReceive('resolveRouteBinding')
+                 ->once()
+                 ->with(5)
+                 ->andReturn(null);
+        app()->instance(User::class, $userMock);
+        
+        $request = [
+            "id"      => 1,
+            "method"  => "fixture@getUserNameCustomLogic",
+            "params"  => [
+                "user" => 5,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        $request = json_encode($request, JSON_THROW_ON_ERROR);
+        
+        $response = [
+            'id' => 1,
+            'error' => [
+                'code' => -32000,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        
+        return $this
+            ->call('POST', route('rpc.point'), [], [], [], [], $request)
+            ->assertOk()
+            ->assertHeader('content-type', 'application/json')
+            ->assertJson($response);
+    }
+    
+    /**
+     * @testdox We should get an error, if the object returned by {@see BindsParameters::resolveParameter()}
+     *          does not correspond to the type of object expected by the Procedure method.
+     */
+    public function testCutomLogicInvalidType()
+    {
+        config()->set('app.debug', false);
+        $userMock = \Mockery::mock(User::class);
+        $userMock->shouldReceive('resolveRouteBinding')
+                 ->once()
+                 ->with(5)
+                 ->andReturn(new \stdClass());
+        app()->instance(User::class, $userMock);
+    
+        $request = [
+            "id"      => 1,
+            "method"  => "fixture@getUserNameCustomLogic",
+            "params"  => [
+                "user" => 5,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        $request = json_encode($request, JSON_THROW_ON_ERROR);
+    
+        $response = [
+            'id' => 1,
+            'error' => [
+                'code' => -32001,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        
+        return $this
+            ->call('POST', route('rpc.point'), [], [], [], [], $request)
+            ->assertOk()
+            ->assertHeader('content-type', 'application/json')
+            ->assertJson($response);
+    }
+    
+    /**
+     * @testdox We should get an error, if the object expected by the Procedure method
+     *          does not implement {@see UrlRoutable}, but is expected to be resolved
+     *          by the default resolution logic based on {@see BindsParameters::getBindings()}.
+     */
+    public function testDefaultInvalidType()
+    {
+        config()->set('app.debug', false);
+        $userMock = \Mockery::mock(User::class);
+        app()->instance(User::class, $userMock);
+        
+        $request = [
+            "id"      => 1,
+            "method"  => "fixture@getUserNameWrong",
+            "params"  => [
+                "user" => 1,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        $request = json_encode($request, JSON_THROW_ON_ERROR);
+        
+        $response = [
+            'id' => 1,
+            'error' => [
+                'code' => -32002,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        
+        return $this
+            ->call('POST', route('rpc.point'), [], [], [], [], $request)
+            ->assertOk()
+            ->assertHeader('content-type', 'application/json')
+            ->assertJson($response);
+    }
+    
+    /**
+     * @testdox We should get an error, if the Model instance cannot be resolved
+     *          automatically, e.g. due to invalid ID.
+     */
+    public function testDefaultNotFound()
+    {
+        config()->set('app.debug', false);
+        $userMock = \Mockery::mock(User::class);
+        app()->instance(User::class, $userMock);
+        $userMock->shouldReceive('resolveRouteBinding')
+                 ->once()
+                 ->with(1, null)
+                 ->andReturnFalse();
+    
+        $request = [
+            "id"      => 1,
+            "method"  => "fixture@getUserNameDefaultKey",
+            "params"  => [
+                "user" => 1,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        $request = json_encode($request, JSON_THROW_ON_ERROR);
+        
+        $response = [
+            'id' => 1,
+            'error' => [
+                'code' => -32003,
+            ],
+            "jsonrpc" => "2.0",
+        ];
+        
+        return $this
+            ->call('POST', route('rpc.point'), [], [], [], [], $request)
+            ->assertOk()
+            ->assertHeader('content-type', 'application/json')
+            ->assertJson($response);
+    }
+}


### PR DESCRIPTION
## Introduction
I've been a bit disappointed to loose the ability to automatically bind method parameters based on the requests. With a REST-ish interface Laravel provides the [Route Model Binding](https://laravel.com/docs/8.x/routing#route-model-binding) feature, which makes it convenient to just type-hint models on the controller methods, and let them be automatically resolved and injected to be used.
I could see an explicit mention of a workaround in the [documentation](https://sajya.github.io/docs/requests/), but I wanted to achieve something which provides a more elegant syntax to do it so.

## Considerations
I've been looking at how the default *Route Model Binding* works and tried to achieve a similar level of convenience, however since with the RPC route definition all Procedure classes are listed together, defining the parameter bindings in the route files would create convoluted and hard to read syntax.
Also while the default *Route Model Binding* provides the [`Route::model()`](https://laravel.com/docs/8.x/routing#explicit-binding) and the [`Route::bind()`](https://laravel.com/docs/8.x/routing#customizing-the-resolution-logic) methods, they require the registration of a new Service and Facade accessors and I wanted to keep the solution to minimal and to implement with adding the least overhead to the library.

## Solution
Since the official recommentation to work around the problem was already to use custom `FormRequest` instances on the Procedure methods, I think it is kind of easy to add the additional binding definitions there too. This way the implementer gets the full control over how to resolve the custom parameters, but can rely on the service container to help with the binding and after all simply just type hint what they need on the Procedure methods.

The entry point of the solution is the `HandleProcedure::handle()` method, where I've replaced
`App::call($this->procedure);`
with
`BoundMethod::call(app(), $this->procedure);`
which is pretty much the same, however by this change we can extend the `\Illuminate\Container\BoundMethod::addDependencyForCallParameter()` with the custom logic needed to inject the parameters.

The only catch is that the `FormRequest` parameter must come **before** any of the type hinted parameters that need custom resolution logic to apply. This is because `addDependencyForCallParameter()` resolves the parameters in the order they are needed for the Procedure method. So the first parameter is a `FormRequest` (or in fact any class) that implements the new `BindsParameters` Interface. During the resolution of the subsequent parameters, `addDependencyForCallParameter()` first checks each previously resolved parameters if they implement the `BindsParameters` Interface, and if so, uses them for the resolution. If there is no such parameters or no matches to be resolved, it passes the resolution back to `parent::addDependencyForCallParameter()` ensuring the implementation stays compatible with the original behaviour, if someone does not use custom `FormRequests` or the `BindsParameters` Interface.

Now the `BindsParameters` Interface defines two methods to be used for the resolution.
* `resolveParameter()` is the "replacement" for [`Route::bind()`](https://laravel.com/docs/8.x/routing#customizing-the-resolution-logic). It receives the name of the argument of the Procedure method, and expects the dependency instance to be returned. False can be returned to indicate to proceed with the rest of the resolution methods. `null` can be also used, if the parameter is optional.
* `getBindings()` is the "replacement" for the default [Implicit Binding](https://laravel.com/docs/8.x/routing#implicit-binding). Since the Route files do not define how request parameters corresponds to Model parameters, "implicit" binding is not possible: it must be explicit. On the other hand, while [`Route::model()`](https://laravel.com/docs/8.x/routing#explicit-binding) really matches the route parameters to Model types, in our case this is not needed, since the Model type can always be determined by the type hint on the Procedure method. What we need instead is a way to explicitly specify which parameters of the RPC request correspond to which parameter of the Processor method: the `getBindings()` therefore should return an array mapping the Processor method parameters to the RPC request parameters.
The resolution follows the same logic as for route parameters. By default the request parameter is expected to contain a primary key (id or whatever is defined as the key of the given Model), or may contain other keys, in the same fashion as for [route model binding using custom keys](https://laravel.com/docs/8.x/routing#customizing-the-default-key-name); the parameter and the key separated using a colon, e.g.: `post:slug`.

Resolution by `resolveParameter()` takes precedence over resolution based on the `getBindings()`, and `getBindings()` takes precedence over the default resolution by the service container.

### Note
Since any parameter that implements the `BindsParameters` interface can resolve subsequent dependencies, it is also possible to use a separate `Request` or `FormRequest` and another dependency of a `BindsParameters` class, effectively separating the Request from the Resolution, but this is more like a sideefect than a feature, tho someone may find it useful to use different `FormRequest` casses with the same `BindsParametersClass` or using the same `FormRequest` with a different `BindsParametersClass` for different methods.

## Examples
You can find the tests in the PR, which indicates how to use the bindings:
* `FixtureRequest` demonstrates the implementation of `BindsParameters::getBindings()` and `BindsParameters::resolveParameter()`.
* `FixtureProcedure` has been extended with few new `getUserName...` methods, which utilise the parameter resolution (and suit the test cases).

In the Test cases I've user the `Illuminate\Foundation\Auth\User` as the type to be resolved to avoid adding an additional fixture class to the library just for the tests' sake. 

## Questions
### Error codes
I've read the error code section of the [JSON:RPC documentation](https://www.jsonrpc.org/specification#error_object), but couldn't truly figure out what the ranges really mean. I came to the conclusion that the library implementing the standard may use the codes between -32000 to -32099 so I've assigned few of those in the new `BoundMethod` class to various resolution issues, but please advice if this usage is correct or should it use different codes?

### Documentation
The contribution guide says documentation is expected with patches, but would that mean to submit a separate PR against the https://github.com/sajya/sajya.github.io repo with the documentation?

***

Please let me know what do you think. I hope you find the addition useful! Let me know if something should be changed!