### PR TITLE
If status code is not integer set the code to -1

### DIFF
--- a/src/HandleProcedure.php
+++ b/src/HandleProcedure.php
@@ -70,6 +70,10 @@ class HandleProcedure implements ShouldQueue
                 return new InternalErrorException();
             }
 
+            if (!is_int($code)) {
+                $code = -1;
+            }
+
             return new RuntimeRpcException($message, $code);
         }
     }


### PR DESCRIPTION
There are instances where the status code can be a string. String error codes are quite common when using `pgsql` as a database.  ref - https://www.postgresql.org/docs/13/errcodes-appendix.html

In these cases, the library throw error about type mismatch as it expects the status code to be int.

![image](https://user-images.githubusercontent.com/34255218/137505222-ea83396d-09e9-4cc4-9a6a-c2d29ad7cd6d.png)

This PR simply assigns the code as -1 if the code is not an integer.

