### PR TITLE
Response: static method makeFromResult()

### DIFF
--- a/src/Guide.php
+++ b/src/Guide.php
@@ -92,12 +92,7 @@ class Guide
     {
         $request ??= new Request();
 
-        return tap(
-            new Response(),
-            fn (Response $response) => $response->setId($request->getId())
-                ->setVersion($request->getVersion())
-                ->setResult($result)
-        );
+        return Response::makeFromResult($result, $request);
     }
 
     /**

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -38,6 +38,24 @@ class Response implements JsonSerializable
     protected ?string $version;
 
     /**
+     * Make Response instance based on result and request.
+     *
+     * @param mixed   $result
+     * @param Request $request
+     *
+     * @return self
+     */
+    public static function makeFromResult($result, Request $request): self
+    {
+        return tap(
+            new self(),
+            fn (Response $response) => $response->setId($request->getId())
+                ->setVersion($request->getVersion())
+                ->setResult($result)
+        );
+    }
+
+    /**
      * @return array
      */
     public function jsonSerialize(): array


### PR DESCRIPTION
This small change allows you to create the Sajya\Server\Http\Result instances not only inside the Sajya\Server\Guide

Also, makes forwarding (#29) of requests a lot easier.