### PR TITLE
Adds callHttpProcedure method which calls the procedure without any chained assertions

### DIFF
--- a/src/Testing/ProceduralRequests.php
+++ b/src/Testing/ProceduralRequests.php
@@ -51,13 +51,26 @@ trait ProceduralRequests
     public function callProcedure(string $method, array $content = [], $id = 1): TestResponse
     {
         return $this
-            ->json('POST', $this->rpcEndpoint, [
-                'jsonrpc' => '2.0',
-                'id'      => $id,
-                'method'  => $method,
-                'params'  => $content,
-            ])
+            ->callHttpProcedure($method, $content, $id)
             ->assertOk()
             ->assertHeader('content-type', 'application/json');
+    }
+
+
+    /**
+     * @param string          $method
+     * @param array           $content
+     * @param string|int|null $id
+     *
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function callHttpProcedure(string $method, array $content = [], $id = 1): TestResponse
+    {
+        return $this->json('POST', $this->rpcEndpoint, [
+            'jsonrpc' => '2.0',
+            'id'      => $id,
+            'method'  => $method,
+            'params'  => $content,
+        ]);
     }
 }


### PR DESCRIPTION
This is backwards compatible. This allows for us to re-use the nice original callProcedure method, but without the assumed assertions, so that we can test transport layer errors while re-using the same json POST payload building that this function nicely offers.

https://github.com/sajya/server/issues/36