### PR TITLE
Feature/error reporting

### DIFF
--- a/src/HandleProcedure.php
+++ b/src/HandleProcedure.php
@@ -13,14 +13,12 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\App;
 use Illuminate\Validation\ValidationException;
-use RuntimeException;
 use Sajya\Server\Exceptions\InternalErrorException;
 use Sajya\Server\Exceptions\InvalidParams;
 use Sajya\Server\Exceptions\RpcException;
 use Sajya\Server\Exceptions\RuntimeRpcException;
 use Sajya\Server\Facades\RPC;
 use Sajya\Server\Http\Request;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class HandleProcedure implements ShouldQueue
 {
@@ -59,32 +57,27 @@ class HandleProcedure implements ShouldQueue
             $parameters = RPC::bindResolve($this->procedure, $this->request->getParams());
 
             return App::call($this->procedure, $parameters);
-        } catch (HttpException | RuntimeException | Exception $exception) {
+        } catch (Exception $exception) {
             app()->get(ExceptionHandler::class)->report($exception);
 
             if ($exception instanceof RpcException) {
                 return $exception;
-            }
-
-            $message = $exception->getMessage();
-
-            $code = method_exists($exception, 'getStatusCode')
-                ? $exception->getStatusCode()
-                : $exception->getCode();
-
-            if ($exception instanceof ValidationException) {
+            } else if ($exception instanceof ValidationException) {
                 return new InvalidParams($exception->validator->errors()->toArray());
-            }
+            } else {
+                $code = method_exists($exception, 'getStatusCode')
+                    ? $exception->getStatusCode()
+                    : $exception->getCode();
 
-            if ($code === 500) {
-                return new InternalErrorException();
-            }
+                if ($code === 500) {
+                    return new InternalErrorException();
+                }
 
-            if (! is_int($code)) {
-                $code = -1;
+                return new RuntimeRpcException(
+                    $exception->getMessage(),
+                    is_int($code) ? $code : -1
+                );
             }
-
-            return new RuntimeRpcException($message, $code);
         }
     }
 }

--- a/src/HandleProcedure.php
+++ b/src/HandleProcedure.php
@@ -6,6 +6,7 @@ namespace Sajya\Server;
 
 use Exception;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -59,6 +60,8 @@ class HandleProcedure implements ShouldQueue
 
             return App::call($this->procedure, $parameters);
         } catch (HttpException | RuntimeException | Exception $exception) {
+            app()->get(ExceptionHandler::class)->report($exception);
+
             if ($exception instanceof RpcException) {
                 return $exception;
             }


### PR DESCRIPTION
1. #38 Finally, I figured out that it's not necessarily rendering exception with error handler. Exceptions need to transform must extend RpcException. What I need is just error reporting.
2. All exceptions will be caught by `Exception`, these is no need to catch `HttpException` or `RuntimeException`.
```php
        } catch (HttpException | RuntimeException | Exception $exception) {
```
[origin code](https://github.com/sajya/server/blob/f933dfd7ea867f4e957935a9a8e9f8c2dd9e31f0/src/HandleProcedure.php#L61)