### PR TITLE
Added reporting exceptions

### DIFF
--- a/src/Exceptions/InvalidParams.php
+++ b/src/Exceptions/InvalidParams.php
@@ -34,4 +34,14 @@ class InvalidParams extends RpcException
     {
         return 'Invalid params';
     }
+
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report(): ?bool
+    {
+        return true;
+    }
 }

--- a/src/Exceptions/InvalidRequestException.php
+++ b/src/Exceptions/InvalidRequestException.php
@@ -34,4 +34,14 @@ class InvalidRequestException extends RpcException
     {
         return 'Invalid Request';
     }
+
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report(): ?bool
+    {
+        return true;
+    }
 }

--- a/src/Exceptions/MethodNotFound.php
+++ b/src/Exceptions/MethodNotFound.php
@@ -34,4 +34,14 @@ class MethodNotFound extends RpcException
     {
         return 'Method not found';
     }
+
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report(): ?bool
+    {
+        return true;
+    }
 }

--- a/src/Exceptions/ParseErrorException.php
+++ b/src/Exceptions/ParseErrorException.php
@@ -35,4 +35,14 @@ class ParseErrorException extends RpcException
     {
         return 'Parse error';
     }
+
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report(): ?bool
+    {
+        return true;
+    }
 }

--- a/src/Exceptions/RuntimeRpcException.php
+++ b/src/Exceptions/RuntimeRpcException.php
@@ -23,4 +23,14 @@ class RuntimeRpcException extends RpcException
     {
         return -1;
     }
+
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report()
+    {
+        return true;
+    }
 }

--- a/src/HandleProcedure.php
+++ b/src/HandleProcedure.php
@@ -88,7 +88,7 @@ class HandleProcedure implements ShouldQueue
             return new InternalErrorException();
         }
 
-        if (!is_int($code)) {
+        if (! is_int($code)) {
             $code = -1;
         }
 

--- a/src/HandleProcedure.php
+++ b/src/HandleProcedure.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sajya\Server;
 
-use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -12,14 +11,13 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\App;
 use Illuminate\Validation\ValidationException;
-use RuntimeException;
 use Sajya\Server\Exceptions\InternalErrorException;
 use Sajya\Server\Exceptions\InvalidParams;
 use Sajya\Server\Exceptions\RpcException;
 use Sajya\Server\Exceptions\RuntimeRpcException;
 use Sajya\Server\Facades\RPC;
 use Sajya\Server\Http\Request;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
 
 class HandleProcedure implements ShouldQueue
 {
@@ -58,30 +56,42 @@ class HandleProcedure implements ShouldQueue
             $parameters = RPC::bindResolve($this->procedure, $this->request->getParams());
 
             return App::call($this->procedure, $parameters);
-        } catch (HttpException | RuntimeException | Exception $exception) {
-            if ($exception instanceof RpcException) {
-                return $exception;
-            }
-
-            $message = $exception->getMessage();
-
-            $code = method_exists($exception, 'getStatusCode')
-                ? $exception->getStatusCode()
-                : $exception->getCode();
-
-            if ($exception instanceof ValidationException) {
-                return new InvalidParams($exception->validator->errors()->toArray());
-            }
-
-            if ($code === 500) {
-                return new InternalErrorException();
-            }
-
-            if (! is_int($code)) {
-                $code = -1;
-            }
-
-            return new RuntimeRpcException($message, $code);
+        } catch (Throwable $exception) {
+            return $this->handleException($exception);
         }
+    }
+
+    /**
+     * Handle the exception into JSON-RPC.
+     *
+     * @param Throwable $exception
+     *
+     * @return string|RpcException|\Illuminate\Http\Response
+     */
+    protected function handleException($exception)
+    {
+        report($exception);
+
+        if ($exception instanceof ValidationException) {
+            return new InvalidParams($exception->validator->errors()->toArray());
+        }
+
+        if ($exception instanceof RpcException) {
+            return $exception;
+        }
+
+        $code = method_exists($exception, 'getStatusCode')
+            ? $exception->getStatusCode()
+            : $exception->getCode();
+
+        if ($code === 500) {
+            return new InternalErrorException();
+        }
+
+        if (!is_int($code)) {
+            $code = -1;
+        }
+
+        return new RuntimeRpcException($exception->getMessage(), $code);
     }
 }

--- a/tests/Expected/Requests/testDivisionException.json
+++ b/tests/Expected/Requests/testDivisionException.json
@@ -1,0 +1,9 @@
+{
+    "jsonrpc": "2.0",
+    "method": "fixture@division",
+    "params": {
+        "a": 4,
+        "b": 0
+    },
+    "id": 1
+}

--- a/tests/Expected/Requests/testReportException.json
+++ b/tests/Expected/Requests/testReportException.json
@@ -1,0 +1,5 @@
+{
+    "jsonrpc": "2.0",
+    "method": "fixture@reportException",
+    "id": 1
+}

--- a/tests/Expected/Responses/testDivisionException.json
+++ b/tests/Expected/Responses/testDivisionException.json
@@ -1,0 +1,8 @@
+{
+    "id": "1",
+    "error": {
+        "code": 0,
+        "message": "Division by zero"
+    },
+    "jsonrpc": "2.0"
+}

--- a/tests/Expected/Responses/testReportException.json
+++ b/tests/Expected/Responses/testReportException.json
@@ -1,0 +1,8 @@
+{
+    "id": "1",
+    "error": {
+        "code": 0,
+        "message": "Report exception"
+    },
+    "jsonrpc": "2.0"
+}

--- a/tests/Fixture/ReportException.php
+++ b/tests/Fixture/ReportException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server\Tests\Fixture;
+
+use Exception;
+
+class ReportException extends Exception
+{
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report()
+    {
+        config()->set('render-response-exception', 'Enabled');
+
+        return true;
+    }
+}

--- a/tests/FixtureProcedure.php
+++ b/tests/FixtureProcedure.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 use Sajya\Server\Exceptions\InvalidRequestException;
 use Sajya\Server\Exceptions\RuntimeRpcException;
 use Sajya\Server\Procedure;
+use Sajya\Server\Tests\Fixture\ReportException;
 
 class FixtureProcedure extends Procedure
 {
@@ -69,6 +70,16 @@ class FixtureProcedure extends Procedure
     }
 
     /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return float|int
+     */
+    public function division(Request $request): float|int
+    {
+        return $request->get('a') / $request->get('b');
+    }
+
+    /**
      * @param Request $request
      *
      * @return int
@@ -82,7 +93,7 @@ class FixtureProcedure extends Procedure
 
         $result = $request->get('a') + $request->get('b');
 
-        Log::info('Result procedure: '.$result);
+        Log::info('Result procedure: ' . $result);
 
         return $result;
     }
@@ -108,17 +119,32 @@ class FixtureProcedure extends Procedure
         return 'Ok';
     }
 
+    /**
+     * @return mixed
+     */
     public function runtimeError()
     {
         throw new RuntimeRpcException();
     }
 
+    /**
+     * @return mixed
+     */
     public function invalidRequestException()
     {
-        throw new  InvalidRequestException([
+        throw new InvalidRequestException([
             'foo' => 'bar',
             'baz' => 'qux',
         ]);
+    }
+
+    /**
+     * @return mixed
+     * @throws ReportException
+     */
+    public function reportException()
+    {
+        throw new ReportException('Report exception');
     }
 
     /**

--- a/tests/FixtureProcedure.php
+++ b/tests/FixtureProcedure.php
@@ -139,8 +139,9 @@ class FixtureProcedure extends Procedure
     }
 
     /**
-     * @return mixed
      * @throws ReportException
+     *
+     * @return mixed
      */
     public function reportException()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,8 +29,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
-        collect(glob(storage_path('logs/*.log')))
-            ->each(fn (string $path) => unlink($path));
+        collect(glob(storage_path('logs/*.log')))->each(fn(string $path) => unlink($path));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,7 +29,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
-        collect(glob(storage_path('logs/*.log')))->each(fn(string $path) => unlink($path));
+        collect(glob(storage_path('logs/*.log')))->each(fn (string $path) => unlink($path));
     }
 
     /**

--- a/tests/Unit/ExpectedTest.php
+++ b/tests/Unit/ExpectedTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Testing\TestResponse;
 use Sajya\Server\Facades\RPC;
 use Sajya\Server\Tests\FixtureBind;
+use Sajya\Server\Tests\ReportException;
 use Sajya\Server\Tests\TestCase;
 
 class ExpectedTest extends TestCase
@@ -83,6 +84,14 @@ class ExpectedTest extends TestCase
         yield ['testRuntimeError'];
         yield ['testInvalidRequestException'];
         yield ['testCallNoExistMethod'];
+
+        // Exception
+        yield ['testDivisionException'];
+        yield ['testReportException', function () {
+            $this->assertNull(config('render-response-exception'));
+        }, function () {
+            $this->assertStringContainsString('Enabled', config('render-response-exception'));
+        }];
 
         // Binding
         yield ['testBindDeepValue',];

--- a/tests/Unit/ExpectedTest.php
+++ b/tests/Unit/ExpectedTest.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Testing\TestResponse;
 use Sajya\Server\Facades\RPC;
 use Sajya\Server\Tests\FixtureBind;
-use Sajya\Server\Tests\ReportException;
 use Sajya\Server\Tests\TestCase;
 
 class ExpectedTest extends TestCase


### PR DESCRIPTION
This is implementation #38 #39 with some very simple flag added so that we know for sure that it is being intercepted. It has also been added as untracked exceptions such as method not found or invalid parameters. (Like for example laravel doesn't log errors like 404 or CSRF token issues.)