### PR TITLE
Added Proxy procedure

### DIFF
--- a/src/Guide.php
+++ b/src/Guide.php
@@ -104,7 +104,7 @@ class Guide
     public function handleProcedure(Request $request, bool $notification): Response
     {
         request()->replace($request->getParams()->toArray());
-        app()->bind(Request::class, fn() => $request);
+        app()->bind(Request::class, fn () => $request);
 
         $procedure = $this->findProcedure($request);
 
@@ -132,10 +132,10 @@ class Guide
         $method = Str::afterLast($request->getMethod(), $this->delimiter);
 
         return $this->map
-            ->filter(fn(string $procedure) => $this->getProcedureName($procedure) === $class)
-            ->filter(fn(string $procedure) => $this->checkExistPublicMethod($procedure, $method))
-            ->map(fn(string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER . $method))
-            ->whenEmpty(fn(Collection $collection) => $collection->push($this->findProxy($class)))
+            ->filter(fn (string $procedure) => $this->getProcedureName($procedure) === $class)
+            ->filter(fn (string $procedure) => $this->checkExistPublicMethod($procedure, $method))
+            ->map(fn (string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER.$method))
+            ->whenEmpty(fn (Collection $collection) => $collection->push($this->findProxy($class)))
             ->first();
     }
 
@@ -149,9 +149,9 @@ class Guide
     public function findProxy(string $class): ?string
     {
         return $this->map
-            ->filter(fn(string $procedure) => $this->getProcedureName($procedure) === $class)
-            ->filter(fn(string $procedure) => is_subclass_of($procedure, Proxy::class))
-            ->map(fn(string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER . '__invoke'))
+            ->filter(fn (string $procedure) => $this->getProcedureName($procedure) === $class)
+            ->filter(fn (string $procedure) => is_subclass_of($procedure, Proxy::class))
+            ->map(fn (string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER.'__invoke'))
             ->first();
     }
 

--- a/src/Guide.php
+++ b/src/Guide.php
@@ -94,6 +94,8 @@ class Guide
     }
 
     /**
+     * Search for a procedure and execute it.
+     *
      * @param Request $request
      * @param bool    $notification
      *
@@ -101,7 +103,8 @@ class Guide
      */
     public function handleProcedure(Request $request, bool $notification): Response
     {
-        \request()->replace($request->getParams()->toArray());
+        request()->replace($request->getParams()->toArray());
+        app()->bind(Request::class, fn() => $request);
 
         $procedure = $this->findProcedure($request);
 
@@ -117,6 +120,8 @@ class Guide
     }
 
     /**
+     * Find procedure by request.
+     *
      * @param Request $request
      *
      * @return null|string
@@ -127,10 +132,26 @@ class Guide
         $method = Str::afterLast($request->getMethod(), $this->delimiter);
 
         return $this->map
-            ->filter(fn (string $procedure) => $this->getProcedureName($procedure) === $class)
-            ->filter(fn (string $procedure) => method_exists($procedure, $method))
-            ->filter(fn (string $procedure) => $this->checkExistPublicMethod($procedure, $method))
-            ->map(fn (string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER.$method))
+            ->filter(fn(string $procedure) => $this->getProcedureName($procedure) === $class)
+            ->filter(fn(string $procedure) => $this->checkExistPublicMethod($procedure, $method))
+            ->map(fn(string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER . $method))
+            ->whenEmpty(fn(Collection $collection) => $collection->push($this->findProxy($class)))
+            ->first();
+    }
+
+    /**
+     * Fallback to the first procedure that implements the Proxy interface.
+     *
+     * @param string $class
+     *
+     * @return null|string
+     */
+    public function findProxy(string $class): ?string
+    {
+        return $this->map
+            ->filter(fn(string $procedure) => $this->getProcedureName($procedure) === $class)
+            ->filter(fn(string $procedure) => is_subclass_of($procedure, Proxy::class))
+            ->map(fn(string $procedure) => Str::finish($procedure, self::DEFAULT_DELIMITER . '__invoke'))
             ->first();
     }
 
@@ -142,7 +163,7 @@ class Guide
      */
     private function checkExistPublicMethod(string $procedure, string $method): bool
     {
-        return (new ReflectionMethod($procedure, $method))->isPublic();
+        return method_exists($procedure, $method) && (new ReflectionMethod($procedure, $method))->isPublic();
     }
 
     /**

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server;
+
+use Sajya\Server\Http\Request;
+
+interface Proxy
+{
+    /**
+     * The method used by request handlers.
+     *
+     * @param \Sajya\Server\Http\Request $request
+     *
+     * @return mixed
+     */
+    public function __invoke(Request $request): mixed;
+}

--- a/tests/Expected/Requests/testFindMethod.json
+++ b/tests/Expected/Requests/testFindMethod.json
@@ -1,5 +1,5 @@
 {
     "jsonrpc": "2.0",
-    "method": "fixture@foobar",
+    "method": "foobar",
     "id": "1"
 }

--- a/tests/Expected/Requests/testProxyMethod.json
+++ b/tests/Expected/Requests/testProxyMethod.json
@@ -1,0 +1,13 @@
+{
+    "jsonrpc": "2.0",
+    "method": "proxy@any",
+    "params": {
+        "firstname": "Vere",
+        "lastname": "Bonilla",
+        "city": "Padang",
+        "country": "Jordan",
+        "countryCode": "BE",
+        "group": "default"
+    },
+    "id": "1"
+}

--- a/tests/Expected/Responses/testBindDeepValue.json
+++ b/tests/Expected/Responses/testBindDeepValue.json
@@ -1,5 +1,5 @@
 {
     "id": "1",
-    "result": "Alexandr",
+    "result": "binding@deepValue Alexandr",
     "jsonrpc": "2.0"
 }

--- a/tests/Expected/Responses/testFindMethod.json
+++ b/tests/Expected/Responses/testFindMethod.json
@@ -1,0 +1,9 @@
+{
+    "jsonrpc": "2.0",
+    "error": {
+        "code": -32601,
+        "message": "Method not found",
+        "data": null
+    },
+    "id": "1"
+}

--- a/tests/Expected/Responses/testProxyMethod.json
+++ b/tests/Expected/Responses/testProxyMethod.json
@@ -1,0 +1,12 @@
+{
+    "id": "1",
+    "result": {
+        "firstname": "Vere",
+        "lastname": "Bonilla",
+        "city": "Padang",
+        "country": "Jordan",
+        "countryCode": "BE",
+        "group": "default"
+    },
+    "jsonrpc": "2.0"
+}

--- a/tests/FixtureBindProcedure.php
+++ b/tests/FixtureBindProcedure.php
@@ -25,7 +25,7 @@ class FixtureBindProcedure extends Procedure
      */
     public function deepValue(Request $request, string $nameDeepValue): string
     {
-        return $request->getMethod() . ' ' . $nameDeepValue;
+        return $request->getMethod().' '.$nameDeepValue;
     }
 
     /**

--- a/tests/FixtureBindProcedure.php
+++ b/tests/FixtureBindProcedure.php
@@ -25,7 +25,7 @@ class FixtureBindProcedure extends Procedure
      */
     public function deepValue(Request $request, string $nameDeepValue): string
     {
-        return $nameDeepValue;
+        return $request->getMethod() . ' ' . $nameDeepValue;
     }
 
     /**

--- a/tests/FixtureProxyProcedure.php
+++ b/tests/FixtureProxyProcedure.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sajya\Server\Tests;
+
+use Sajya\Server\Http\Request;
+use Sajya\Server\Procedure;
+use Sajya\Server\Proxy;
+
+class FixtureProxyProcedure extends Procedure implements Proxy
+{
+    /**
+     * The name of the procedure that will be
+     * displayed and taken into account in the search.
+     *
+     * @var string
+     */
+    public static string $name = 'proxy';
+
+    /**
+     * @param \Sajya\Server\Http\Request $request
+     *
+     * @return mixed
+     */
+    public function __invoke(Request $request): mixed
+    {
+        return $request->getParams()->toArray();
+    }
+}

--- a/tests/FixtureProxyProcedure.php
+++ b/tests/FixtureProxyProcedure.php
@@ -19,12 +19,14 @@ class FixtureProxyProcedure extends Procedure implements Proxy
     public static string $name = 'proxy';
 
     /**
+     * The method that will be called if there is no match.
+     *
      * @param \Sajya\Server\Http\Request $request
      *
      * @return mixed
      */
     public function __invoke(Request $request): mixed
     {
-        return $request->getParams()->toArray();
+        return $request->getMethod();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     public array $mapProcedures = [
         FixtureProcedure::class,
         FixtureBindProcedure::class,
+        FixtureProxyProcedure::class,
     ];
 
     /**

--- a/tests/Unit/ExpectedTest.php
+++ b/tests/Unit/ExpectedTest.php
@@ -63,6 +63,7 @@ class ExpectedTest extends TestCase
         yield ['testBatchSum'];
         yield ['testDelimiter', null, null, 'rpc.delimiter'];
         yield ['testDependencyInjection'];
+        yield ['testFindMethod'];
         yield ['testFindProcedure'];
         yield ['testInvalidParams'];
         yield ['testNotificationSum', static function () {
@@ -104,6 +105,9 @@ class ExpectedTest extends TestCase
         yield ['testBindModel', static function () {
             RPC::model('fixtureModel', FixtureBind::class);
         }];
+
+        // Proxy
+        yield ['testProxyMethod'];
     }
 
     /**


### PR DESCRIPTION
When using microservices, you may want to use Sajya as an entry gate and pass the request to other servers. This PR solves the "Method not found" problem. A sign that a procedure must handle all requests that contain its name is the presence of an interface `Proxy`. When no method is found in such a procedure, it will execute the `__invoke` method by passing the JSON-RPC request itself. For example:

```php
use Sajya\Server\Http\Request;
use Sajya\Server\Procedure;
use Sajya\Server\Proxy;

class FixtureProxyProcedure extends Procedure implements Proxy
{
    /**
     * The name of the procedure that will be
     * displayed and taken into account in the search.
     *
     * @var string
     */
    public static string $name = 'proxy';

    /**
     * The method that will be called if there is no match.
     * 
     * @param \Sajya\Server\Http\Request $request
     *
     * @return mixed
     */
    public function __invoke(Request $request): mixed
    {
        return 'Hello '.$request->getId();
    }
}
```

After that, we can call any method of this procedure:

```bash
curl 'http://127.0.0.1:8000/api/v1/endpoint' --data-binary '{"jsonrpc":"2.0","method":"proxy@ping","id":2}'
```

And the result is

```json
{"id": "2", "result": "Hello 2", "jsonrpc": "2.0"}
```