### PR TITLE
Set up the composer file for Laravel 12 compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,15 +15,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         php: [8.4, 8.3, 8.2, 8.1]
-        laravel: ['10.*', '11.*']
+        laravel: ['10.*', '11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
         exclude:
           - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
             php: 8.1
 
     name: P${{ matrix.php }} - ${{ matrix.os }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "ext-json": "*",
-        "laravel/framework": "^10.0|^11.0"
+        "laravel/framework": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^v1.20",
-        "orchestra/testbench": "^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^10.5|^11.0",
-        "phpunit/php-code-coverage": "^10.|^11.0"
+        "phpunit/php-code-coverage": "^10.|^11.0|^12.0"
     },
     "conflict": {
         "league/flysystem": "<3.0.16",


### PR DESCRIPTION
This change won't fix any actual compatibility problems but it will allow the project to be updated to Laravel 12 if it has this library in the composer file. I used this change in my Laravel 12 project, its not a comprehensive analysis but I haven't seen any problems,